### PR TITLE
Fix import issues in client code

### DIFF
--- a/client/src/assets/relationKeys.ts
+++ b/client/src/assets/relationKeys.ts
@@ -102,3 +102,9 @@ export const relationKeys = [
 ];
 
 export const relationKeyIds = Array.from(new Set(relationKeys.map(r => r.id)));
+
+// Filtered exports for specific relation types
+export const profileToTopic = profileRelations.filter(r => r.accepts.includes('topic'));
+export const profileToLocation = profileRelations.filter(r => r.accepts.includes('location'));
+export const topicToTopic = topicRelations.filter(r => r.accepts.includes('topic'));
+export const locationToLocation = locationRelations.filter(r => r.accepts.includes('location'));

--- a/client/src/components/RelationSelect.vue
+++ b/client/src/components/RelationSelect.vue
@@ -24,7 +24,7 @@
 import { ref, onMounted } from 'vue';
 import BigButton from '@/components/common/BigButton.vue';
 import { useProfile } from '@/composables/profileProvider';
-import relationKeys from '@/assets/relationKeys.ts';
+import { relationKeys } from '@/assets/relationKeys.ts';
 
 const props = defineProps({
 

--- a/client/src/components/dialog/ProfileAddDialog.vue
+++ b/client/src/components/dialog/ProfileAddDialog.vue
@@ -22,7 +22,7 @@
 import axios from 'axios';
 import { ref, inject, computed } from 'vue';
 import Title from '@/components/common/Title.vue';
-import ProfileSettings from '@/components/ProfileSettings.vue';
+import ProfileSettings from '@/components/forms/ProfileSettings.vue';
 import SubmitButton from '@/components/common/SubmitButton.vue';
 
 const props = defineProps({

--- a/client/src/views/LandingView.vue
+++ b/client/src/views/LandingView.vue
@@ -18,7 +18,7 @@
 //
 <script setup lang="ts">
 import Container from '@/components/common/Container.vue';
-import SphereCloud from '@/components/sphereCloud.vue';
+import SphereCloud from '@/components/SphereCloud.vue';
 import { useProfile } from '@/composables/profileProvider';
 
 const { profile } = useProfile();


### PR DESCRIPTION
## Summary
- Fix case-sensitive import: `sphereCloud.vue` → `SphereCloud.vue`
- Fix import path: `ProfileSettings.vue` is in `forms/` subdirectory  
- Fix named vs default export: `relationKeys` should be a named import
- Add missing exports: `topicToTopic`, `profileToTopic`, etc. for filtered relation types

## Context
These changes fix build errors that occur when TypeScript checking is enabled. The errors were related to:
1. Case-sensitive file systems not finding the component
2. Incorrect import paths
3. Missing named exports that were expected by other components

## Test plan
- [x] Build succeeds with `pnpm run -F client build-only`
- [ ] Test that all affected components render correctly
- [ ] Verify TypeScript errors are reduced when type checking is enabled

🤖 Generated with [Claude Code](https://claude.ai/code)