### PR TITLE
fix: configure Vite base path for proper asset URLs

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -7,6 +7,7 @@ import vueJsx from '@vitejs/plugin-vue-jsx'
 import federation from '@originjs/vite-plugin-federation'
 
 export default defineConfig({
+  base: process.env.BASE_PATH || '/',
   plugins: [
     vue(),
     vueJsx(),


### PR DESCRIPTION
## Summary

This PR fixes asset loading on GitHub Pages by configuring Vite's base path.

## Problem

After deploying to GitHub Pages at `/tribelike/`, assets were being requested from `/assets/` instead of `/tribelike/assets/`, causing 404 errors.

## Solution

Configure Vite to use the `BASE_PATH` environment variable that's already being set by the GitHub Actions workflow.

## Testing

This ensures assets are loaded from the correct path when deployed to project pages on GitHub Pages.